### PR TITLE
feat: add REST API with metrics tracking and full documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,158 @@
 # my-budget
+
+A personal bill-tracking app organized around bi-monthly pay periods (1st–15th and 16th–end of month). Built with Flask, SQLAlchemy, and SQLite. Ships as a container image and exposes a full REST API.
+
+---
+
+## Features
+
+- Notepad-style UI — one page per pay period with spiral binding aesthetic
+- Navigate forward/backward through pay periods; jump to today with one click
+- Add, edit, and delete bills per period
+- Bill name autocomplete based on past entries
+- Compare any bill to the same period last month and last year
+- Editable budget name (persisted in the database)
+- Font picker — 20 Google Fonts across Handwritten, Sans-serif, Serif, and Monospace groups
+- Full REST API for all CRUD operations and settings management
+- Automatic API metrics collection (call counts, response times per endpoint)
+
+---
+
+## Running with Docker Compose
+
+```bash
+docker compose up -d
+```
+
+The app will be available at `http://localhost:8000`.
+
+The `./data` directory is mounted as a volume so the SQLite database persists across restarts and image updates.
+
+To pull the latest image and restart:
+
+```bash
+docker compose pull && docker compose up -d
+```
+
+---
+
+## Running locally
+
+**Requirements:** Python 3.10+
+
+```bash
+pip install -r requirements.txt
+gunicorn -w 4 -b 0.0.0.0:8000 my-budget:app
+```
+
+---
+
+## Building the image
+
+```bash
+docker build -f Containerfile -t my-budget .
+```
+
+---
+
+## REST API
+
+All API endpoints are prefixed with `/api/`. Requests and responses use JSON.
+
+### Entries
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/entries` | List entries. Filter by `?year=&month=&period=` or `?from=&to=` (YYYY-MM-DD) |
+| `POST` | `/api/entries` | Create an entry. Body: `{"bill_name", "due_date", "amount_due?"}` |
+| `GET` | `/api/entries/<id>` | Get a single entry |
+| `PUT` | `/api/entries/<id>` | Update an entry. Body: any subset of `bill_name`, `due_date`, `amount_due` |
+| `DELETE` | `/api/entries/<id>` | Delete an entry |
+
+**Entry object:**
+```json
+{
+  "id": 1,
+  "bill_name": "Rent",
+  "due_date": "2026-04-01",
+  "amount_due": 1200.00
+}
+```
+
+### Pay periods
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/periods/<year>/<month>/<period>` | All entries for a period with total due and prev/next links |
+
+`period` is `1` (1st–15th) or `2` (16th–end of month).
+
+**Response:**
+```json
+{
+  "year": 2026, "month": 4, "period": 1,
+  "start_date": "2026-04-01",
+  "end_date": "2026-04-15",
+  "total_due": 1450.00,
+  "entries": [...],
+  "prev": {"year": 2026, "month": 3, "period": 2},
+  "next": {"year": 2026, "month": 4, "period": 2}
+}
+```
+
+### Settings
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/settings` | All settings as `{"key": "value"}` |
+| `GET` | `/api/settings/<key>` | Single setting |
+| `PUT` | `/api/settings/<key>` | Update a setting. Body: `{"value": "..."}` |
+
+Available keys: `budget_name`, `font_family`.
+
+### Metrics
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/metrics` | Recent API calls. Query params: `limit` (default 100), `offset` (default 0) |
+| `GET` | `/api/metrics/summary` | Aggregated stats per endpoint — call count, avg/min/max response time |
+
+**Metric object:**
+```json
+{
+  "id": 42,
+  "endpoint": "/api/entries",
+  "method": "GET",
+  "status_code": 200,
+  "response_time_ms": 3.14,
+  "timestamp": "2026-04-13T12:00:00Z"
+}
+```
+
+**Summary object:**
+```json
+{
+  "endpoint": "/api/entries",
+  "method": "GET",
+  "calls": 87,
+  "avg_ms": 4.21,
+  "min_ms": 1.8,
+  "max_ms": 22.5,
+  "first_call": "2026-04-01T08:00:00Z",
+  "last_call": "2026-04-13T11:59:00Z"
+}
+```
+
+---
+
+## Data
+
+The SQLite database is stored at `data/my-budget.db` relative to the project root. When running via Docker Compose, this directory is bind-mounted from the host so data survives container replacement.
+
+## Tech stack
+
+- [Flask](https://flask.palletsprojects.com/) — web framework
+- [Flask-SQLAlchemy](https://flask-sqlalchemy.palletsprojects.com/) — ORM
+- [SQLite](https://www.sqlite.org/) — database
+- [Gunicorn](https://gunicorn.org/) — WSGI server
+- [Google Fonts](https://fonts.google.com/) — typography

--- a/my-budget.py
+++ b/my-budget.py
@@ -1,7 +1,8 @@
-from flask import Flask, jsonify, render_template, request, redirect, url_for
+from flask import Flask, jsonify, render_template, request, redirect, url_for, g
 import calendar
 import datetime
 import os
+import time
 from flask_sqlalchemy import SQLAlchemy
 
 app = Flask(__name__)
@@ -16,6 +17,7 @@ month_names = ['January', 'February', 'March', 'April', 'May', 'June',
 
 
 class Entry(db.Model):
+    """A single bill record tied to a specific due date."""
     id         = db.Column(db.Integer, primary_key=True)
     bill_name  = db.Column(db.String(80), nullable=False)
     due_date   = db.Column(db.Date, nullable=False)
@@ -23,8 +25,20 @@ class Entry(db.Model):
 
 
 class Config(db.Model):
+    """Persistent key/value store for user-facing settings (e.g. budget_name, font_family)."""
     key   = db.Column(db.String(80), primary_key=True)
     value = db.Column(db.String(200), nullable=False)
+
+
+class Metric(db.Model):
+    """One row per API request — used to power the /api/metrics endpoints."""
+    id               = db.Column(db.Integer, primary_key=True)
+    endpoint         = db.Column(db.String(120), nullable=False)
+    method           = db.Column(db.String(10),  nullable=False)
+    status_code      = db.Column(db.Integer,     nullable=False)
+    response_time_ms = db.Column(db.Float,       nullable=False)
+    timestamp        = db.Column(db.DateTime,    nullable=False,
+                                 default=datetime.datetime.utcnow)
 
 
 with app.app_context():
@@ -34,11 +48,13 @@ with app.app_context():
 # ── Config helpers ────────────────────────────────────────────────────────────
 
 def get_config(key, default=''):
+    """Return the stored value for key, or default if the key does not exist."""
     row = Config.query.get(key)
     return row.value if row else default
 
 
 def set_config(key, value):
+    """Upsert a key/value pair in Config."""
     row = Config.query.get(key)
     if row:
         row.value = value
@@ -81,6 +97,7 @@ def get_adjacent_period(year, month, period, direction):
 
 @app.route('/')
 def home():
+    """Redirect to the current pay period based on today's date."""
     now = datetime.datetime.now()
     period = 1 if now.day <= 15 else 2
     return redirect(url_for('pay_period_view', year=now.year, month=now.month, period=period))
@@ -88,6 +105,7 @@ def home():
 
 @app.route('/period/<int:year>/<int:month>/<int:period>', methods=['GET', 'POST'])
 def pay_period_view(year, month, period):
+    """Render the notepad page for a pay period. POST adds a new bill."""
     start_date, end_date = get_pay_period_dates(year, month, period)
 
     if request.method == 'POST':
@@ -143,6 +161,7 @@ def pay_period_view(year, month, period):
 
 @app.route('/edit/<int:id>', methods=['GET', 'POST'])
 def edit(id):
+    """Render the edit form for an existing bill. POST saves changes."""
     entry = Entry.query.get_or_404(id)
 
     if request.method == 'POST':
@@ -167,6 +186,7 @@ def edit(id):
 
 @app.route('/delete/<int:id>', methods=['GET', 'POST'])
 def delete(id):
+    """Render the delete confirmation page. POST permanently removes the bill."""
     entry = Entry.query.get_or_404(id)
 
     if request.method == 'POST':
@@ -181,6 +201,7 @@ def delete(id):
 
 @app.route('/bill-history')
 def bill_history():
+    """Return JSON with last-month and last-year amounts for a named bill (used by the UI history popup)."""
     name   = request.args.get('name', '')
     year   = int(request.args.get('year',   0))
     month  = int(request.args.get('month',  0))
@@ -210,8 +231,254 @@ def bill_history():
 
 @app.route('/settings', methods=['POST'])
 def settings():
+    """Save a UI setting (budget_name, font_family) sent by the frontend via fetch."""
     key   = request.form.get('key', '').strip()
     value = request.form.get('value', '').strip()
     if key and value:
         set_config(key, value)
     return '', 204
+
+
+# ── API metrics hooks ─────────────────────────────────────────────────────────
+
+@app.before_request
+def _api_start_timer():
+    """Record request start time for API routes so response time can be calculated."""
+    if request.path.startswith('/api/'):
+        g.api_start = time.time()
+
+
+@app.after_request
+def _api_record_metric(response):
+    """Persist a Metric row for every completed API request."""
+    if request.path.startswith('/api/') and hasattr(g, 'api_start'):
+        elapsed = round((time.time() - g.api_start) * 1000, 2)
+        try:
+            db.session.add(Metric(
+                endpoint=request.path,
+                method=request.method,
+                status_code=response.status_code,
+                response_time_ms=elapsed,
+            ))
+            db.session.commit()
+        except Exception:
+            db.session.rollback()
+    return response
+
+
+# ── API helpers ───────────────────────────────────────────────────────────────
+
+def entry_to_dict(e):
+    """Serialize an Entry to a JSON-safe dict."""
+    return {
+        'id':         e.id,
+        'bill_name':  e.bill_name,
+        'due_date':   e.due_date.isoformat(),
+        'amount_due': e.amount_due,
+    }
+
+
+def api_error(msg, code=400):
+    """Return a JSON error response with the given message and HTTP status code."""
+    return jsonify({'error': msg}), code
+
+
+# ── API: entries ──────────────────────────────────────────────────────────────
+
+@app.route('/api/entries', methods=['GET'])
+def api_entries_list():
+    """List entries. Optional filters: year+month+period  OR  from+to (YYYY-MM-DD)."""
+    q = Entry.query
+
+    year   = request.args.get('year',   type=int)
+    month  = request.args.get('month',  type=int)
+    period = request.args.get('period', type=int)
+    from_  = request.args.get('from')
+    to_    = request.args.get('to')
+
+    if year and month and period:
+        start, end = get_pay_period_dates(year, month, period)
+        q = q.filter(Entry.due_date >= start, Entry.due_date <= end)
+    elif from_ or to_:
+        if from_:
+            q = q.filter(Entry.due_date >= datetime.date.fromisoformat(from_))
+        if to_:
+            q = q.filter(Entry.due_date <= datetime.date.fromisoformat(to_))
+
+    entries = q.order_by(Entry.due_date).all()
+    return jsonify([entry_to_dict(e) for e in entries])
+
+
+@app.route('/api/entries', methods=['POST'])
+def api_entries_create():
+    """Create a new entry. Body: {bill_name, due_date, amount_due?}"""
+    data = request.get_json(silent=True) or {}
+
+    bill_name    = (data.get('bill_name') or '').strip()
+    due_date_str = (data.get('due_date')  or '').strip()
+    amount_due   = data.get('amount_due', 0.0)
+
+    if not bill_name or not due_date_str:
+        return api_error('bill_name and due_date are required')
+
+    try:
+        due_date = datetime.date.fromisoformat(due_date_str)
+    except ValueError:
+        return api_error('due_date must be YYYY-MM-DD')
+
+    entry = Entry(bill_name=bill_name, due_date=due_date,
+                  amount_due=float(amount_due) if amount_due else 0.0)
+    db.session.add(entry)
+    db.session.commit()
+    return jsonify(entry_to_dict(entry)), 201
+
+
+@app.route('/api/entries/<int:entry_id>', methods=['GET'])
+def api_entry_get(entry_id):
+    """Return a single entry by ID."""
+    entry = Entry.query.get_or_404(entry_id)
+    return jsonify(entry_to_dict(entry))
+
+
+@app.route('/api/entries/<int:entry_id>', methods=['PUT'])
+def api_entry_update(entry_id):
+    """Update an entry. Body: {bill_name?, due_date?, amount_due?}"""
+    entry = Entry.query.get_or_404(entry_id)
+    data  = request.get_json(silent=True) or {}
+
+    if 'bill_name' in data:
+        bill_name = data['bill_name'].strip()
+        if not bill_name:
+            return api_error('bill_name cannot be empty')
+        entry.bill_name = bill_name
+
+    if 'due_date' in data:
+        try:
+            entry.due_date = datetime.date.fromisoformat(data['due_date'])
+        except ValueError:
+            return api_error('due_date must be YYYY-MM-DD')
+
+    if 'amount_due' in data:
+        entry.amount_due = float(data['amount_due'])
+
+    db.session.commit()
+    return jsonify(entry_to_dict(entry))
+
+
+@app.route('/api/entries/<int:entry_id>', methods=['DELETE'])
+def api_entry_delete(entry_id):
+    """Delete an entry by ID. Returns 204 No Content on success."""
+    entry = Entry.query.get_or_404(entry_id)
+    db.session.delete(entry)
+    db.session.commit()
+    return '', 204
+
+
+# ── API: pay periods ──────────────────────────────────────────────────────────
+
+@app.route('/api/periods/<int:year>/<int:month>/<int:period>', methods=['GET'])
+def api_period_summary(year, month, period):
+    """Return all entries for a pay period plus totals and adjacent period links."""
+    if period not in (1, 2):
+        return api_error('period must be 1 or 2')
+
+    start, end = get_pay_period_dates(year, month, period)
+    entries = Entry.query.filter(
+        Entry.due_date >= start,
+        Entry.due_date <= end
+    ).order_by(Entry.due_date).all()
+
+    py, pm, pp = get_adjacent_period(year, month, period, 'prev')
+    ny, nm, np = get_adjacent_period(year, month, period, 'next')
+
+    return jsonify({
+        'year': year, 'month': month, 'period': period,
+        'start_date': start.isoformat(),
+        'end_date':   end.isoformat(),
+        'total_due':  round(sum(e.amount_due for e in entries), 2),
+        'entries':    [entry_to_dict(e) for e in entries],
+        'prev': {'year': py, 'month': pm, 'period': pp},
+        'next': {'year': ny, 'month': nm, 'period': np},
+    })
+
+
+# ── API: settings ─────────────────────────────────────────────────────────────
+
+@app.route('/api/settings', methods=['GET'])
+def api_settings_list():
+    """Return all stored settings as a {key: value} dict."""
+    rows = Config.query.all()
+    return jsonify({r.key: r.value for r in rows})
+
+
+@app.route('/api/settings/<key>', methods=['GET'])
+def api_setting_get(key):
+    """Return a single setting by key. 404 if not found."""
+    row = Config.query.get(key)
+    if not row:
+        return api_error(f'setting "{key}" not found', 404)
+    return jsonify({'key': row.key, 'value': row.value})
+
+
+@app.route('/api/settings/<key>', methods=['PUT'])
+def api_setting_set(key):
+    """Update a setting. Body: {value}"""
+    data  = request.get_json(silent=True) or {}
+    value = str(data.get('value', '')).strip()
+    if not value:
+        return api_error('value is required')
+    set_config(key, value)
+    return jsonify({'key': key, 'value': value})
+
+
+# ── API: metrics ──────────────────────────────────────────────────────────────
+
+@app.route('/api/metrics', methods=['GET'])
+def api_metrics_list():
+    """Recent API calls. Query params: limit (default 100), offset (default 0)."""
+    limit  = request.args.get('limit',  100, type=int)
+    offset = request.args.get('offset', 0,   type=int)
+
+    rows = (Metric.query
+            .order_by(Metric.timestamp.desc())
+            .offset(offset).limit(limit).all())
+
+    return jsonify([{
+        'id':               r.id,
+        'endpoint':         r.endpoint,
+        'method':           r.method,
+        'status_code':      r.status_code,
+        'response_time_ms': r.response_time_ms,
+        'timestamp':        r.timestamp.isoformat() + 'Z',
+    } for r in rows])
+
+
+@app.route('/api/metrics/summary', methods=['GET'])
+def api_metrics_summary():
+    """Aggregated stats per endpoint+method."""
+    from sqlalchemy import func
+
+    rows = (db.session.query(
+                Metric.endpoint,
+                Metric.method,
+                func.count().label('calls'),
+                func.avg(Metric.response_time_ms).label('avg_ms'),
+                func.min(Metric.response_time_ms).label('min_ms'),
+                func.max(Metric.response_time_ms).label('max_ms'),
+                func.min(Metric.timestamp).label('first_call'),
+                func.max(Metric.timestamp).label('last_call'),
+            )
+            .group_by(Metric.endpoint, Metric.method)
+            .order_by(func.count().desc())
+            .all())
+
+    return jsonify([{
+        'endpoint':   r.endpoint,
+        'method':     r.method,
+        'calls':      r.calls,
+        'avg_ms':     round(r.avg_ms, 2),
+        'min_ms':     r.min_ms,
+        'max_ms':     r.max_ms,
+        'first_call': r.first_call.isoformat() + 'Z',
+        'last_call':  r.last_call.isoformat()  + 'Z',
+    } for r in rows])


### PR DESCRIPTION
- Add API endpoints for entries (CRUD), pay periods, settings, and metrics
- Add Metric model to persist per-request stats (endpoint, method, status, response time)
- Auto-record metrics via before/after request hooks for all /api/ routes
- Add docstrings to all previously undocumented functions, classes, and routes
- Update README with full API reference, setup instructions, and tech stack